### PR TITLE
adds core activity models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ wheels/
 # ignore logs
 *.log
 
+# ignore vscode
+.vscode/
+
 # ignore duckdb
 *.duckdb
 *.wal

--- a/transform/dbt_project.yml
+++ b/transform/dbt_project.yml
@@ -31,6 +31,8 @@ flags:
 
 models:
   strava_transform:
+    core:
+      +materialized: table
     intermediate:
       +materialized: table
     staging:

--- a/transform/dbt_project.yml
+++ b/transform/dbt_project.yml
@@ -31,5 +31,7 @@ flags:
 
 models:
   strava_transform:
+    intermediate:
+      +materialized: table
     staging:
       +materialized: view

--- a/transform/models/core/fct_activities.sql
+++ b/transform/models/core/fct_activities.sql
@@ -1,0 +1,79 @@
+with activities as (
+    select *
+    from {{ ref('stg_strava_activities') }}
+)
+
+, final as (
+    select
+        activity_id
+        , activity_name
+        , activity_type
+        , sport_type
+        , started_at
+        , started_at_local
+        , timezone
+        , utc_offset_seconds
+        
+        /* Activity stats */
+        , elapsed_seconds
+        , moving_seconds
+        , distance
+        , distance_metric
+        , cadence_avg
+        , hr_avg
+        , hr_max
+        , speed_avg
+        , speed_max
+        , speed_avg_metric
+        , speed_max_metric
+        , watts_avg
+        , watts_weighted_avg
+        , watts_max
+        , temperature_avg
+        , temperature_avg_metric
+        , elevation_min
+        , elevation_max
+        , elevation_gain
+        , elevation_min_metric
+        , elevation_max_metric
+        , kilojoules
+        , calories_burned
+
+        /* Strava stats */
+        , achievement_count
+        , pr_count
+        , suffer_score
+        , athlete_count
+        , comment_count
+        , kudos_count
+        , photo_count
+        , photo_count_at_upload
+
+        /* Flags */
+        , is_commute
+        , is_device_watts
+        , is_flagged
+        , is_friends_activity
+        , has_heartrate
+        , has_heartrate_hidden
+        , has_kudoed
+        , is_manual
+        , is_private
+        , is_trainer
+
+        , athlete_id
+        , external_id
+        , gear_id
+        , map_id
+        , upload_id
+        , visibility
+        , workout_type
+        , location_city
+        , location_country
+        , location_state
+
+    from activities
+)
+
+select *
+from final

--- a/transform/models/core/fct_activities.sql
+++ b/transform/models/core/fct_activities.sql
@@ -26,9 +26,9 @@ with activities as (
         , speed_max
         , speed_avg_metric
         , speed_max_metric
-        , watts_avg
-        , watts_weighted_avg
-        , watts_max
+        , power_avg
+        , power_weighted_avg
+        , power_max
         , temperature_avg
         , temperature_avg_metric
         , elevation_min

--- a/transform/models/core/fct_activities.yml
+++ b/transform/models/core/fct_activities.yml
@@ -1,0 +1,8 @@
+models:
+  - name: fct_activities
+    description: "One row per Strava activity"
+    columns:
+      - name: activity_id
+        tests:
+          - unique
+          - not_null

--- a/transform/models/core/fct_activity_data_points.sql
+++ b/transform/models/core/fct_activity_data_points.sql
@@ -1,0 +1,37 @@
+with stream_points as (
+    select *
+    from {{ ref('int_activity_stream_points') }}
+)
+
+, pivoted as (
+    select
+        activity_id
+        , stream_index
+        , {{ dbt_utils.pivot(
+            'stream_type'
+            , dbt_utils.get_column_values(
+                table=ref('int_activity_stream_points')
+                , column='stream_type'
+                , order_by='stream_type'
+            )
+            , agg='max'
+            , then_value='stream_point'
+            , else_value='null'
+            , quote_identifiers=false
+        ) }}
+
+    from stream_points
+    group by all
+)
+
+, final as (
+    select
+        {{ dbt_utils.generate_surrogate_key(['activity_id', 'stream_index']) }} as activity_data_point_id
+        , pivoted.*
+        , time - lag(time) over (partition by activity_id order by stream_index) as time_delta
+    
+    from pivoted
+)
+
+select *
+from final

--- a/transform/models/core/fct_activity_data_points.yml
+++ b/transform/models/core/fct_activity_data_points.yml
@@ -13,6 +13,52 @@ models:
         tests:
           - not_null
       
+      - name: is_moving
+        description: >
+          Flag to denote whether athlete was moving at this instance of time.
+        tests:
+          - not_null
+          - accepted_values:
+              values: [true, false]
+      
+      - name: time
+        tests:
+          - not_null
+      
+      - name: grade
+        description: >
+          The "smoothed" (or whole number) grade provided by Strava.
+          Unable to calculate an actual grade because it would require a finer granularity
+          than meters for altitude (i.e. ascent often happens at a rate of < 1 m/s).
+        tests:
+          - not_null
+      
+      - name: velocity
+        description: >
+          The exact velocity at each stream index calculated via
+          `distance_delta` / `time_delta`.
+        tests:
+          - not_null:
+              config:
+                # it's possible to have an activity with 0 total distance recorded
+                # in this case, the distance at each stream index will be null
+                where: "distance is not null"
+      
+      - name: velocity_smooth
+        description: >
+          The "smoothed" (or whole number) velocity provided by Strava (in meters/second).
+          When the `time_delta` = 1, this is accurate; however, when the `time_delta` > 1
+          (i.e. there are larger time gaps between stream indexes) this is not as accurate
+          as 1 m/s = 2.2mph = 3.6 kph which can result in significant discrepencies
+          between the smoothed and actual values.
+        tests:
+          - not_null
+      
+      - name: distance_delta
+        description: >
+          Calculates the distance between stream points.
+          For use in calcaulting the exact velocity at each stream index.
+      
       - name: time_delta
         description: >
           Calculates the time bewteen stream data points.

--- a/transform/models/core/fct_activity_data_points.yml
+++ b/transform/models/core/fct_activity_data_points.yml
@@ -1,0 +1,27 @@
+models:
+  - name: fct_activity_data_points
+    description: >
+      One row per activity data point (Strava records 1 data point per second)
+      where all types of streams (time, power, velocity, etc. ) have been pivoted to their own columns.
+    columns:
+      - name: activity_data_point_id
+        tests:
+          - unique
+          - not_null
+      
+      - name: stream_index
+        tests:
+          - not_null
+      
+      - name: time_delta
+        description: >
+          Calculates the time bewteen stream data points.
+          Ideally, a stream records 1 data point per second, however,
+          this can vary based on the GPS device used (sampling rates can differ across devices),
+          activity type, whether or not "battery saver" mode on the device is enabled, etc.
+        tests:
+          # There are small instances of time_delta = 0 as it's
+          # possible (though rare) for streams to get written twice
+          # (e.g. two rows for an activity where time = 300)
+          - dbt_utils.expression_is_true:
+              expression: ">= 0"

--- a/transform/models/core/fct_activity_stream_points.sql
+++ b/transform/models/core/fct_activity_stream_points.sql
@@ -1,0 +1,29 @@
+with activity_streams as (
+    select *
+    from {{ ref('int_activity_streams') }}
+)
+
+, flattened as (
+    select
+        activity_stream_id
+        , activity_id
+        , stream_type
+        , unnest(stream_list) as stream_point
+        , generate_subscripts(stream_list, 1) as stream_index
+        , inserted_at
+
+    from activity_streams
+    /* placeholder to allow fast builds until model is incrementalized */
+    where activity_id = 12183022608
+)
+
+, final as (
+    select
+        {{ dbt_utils.generate_surrogate_key(['activity_stream_id', 'stream_index']) }} as activity_stream_point_id
+        , *
+    
+    from flattened
+)
+
+select *
+from final

--- a/transform/models/core/fct_activity_stream_points.yml
+++ b/transform/models/core/fct_activity_stream_points.yml
@@ -1,0 +1,16 @@
+models:
+  - name: fct_activity_stream_points
+    description: "One row per activity stream data point."
+    columns:
+      - name: activity_stream_point_id
+        tests:
+          - unique
+          - not_null
+      
+      - name: stream_point
+        description: "Singular data point within a stream."
+      
+      - name: stream_index
+        description: "Position of the stream point within the original stream list."
+        tests:
+          - not_null

--- a/transform/models/core/fct_activity_zones.sql
+++ b/transform/models/core/fct_activity_zones.sql
@@ -1,0 +1,32 @@
+with zone_types as (
+    select *
+    from {{ ref('stg_strava_activity_zone_types') }}
+)
+
+, zones as (
+    select *
+    from {{ ref('stg_strava_activity_zones') }}
+)
+
+, joined as (
+    select
+        zones.activity_zone_id
+        , zone_types.activity_id
+        , zone_types.zone_type_id
+        , zone_types.zone_type
+        , zones.min
+        , zones.max
+        , zones.zone_seconds
+        , zones.zone_index
+        , 'Z' || zone_index as zone_name
+        , zone_types.is_sensor_based
+        , zone_types.has_custom_zone_set
+
+    from zone_types
+        /* Very early strava activities (i.e. < 2015) don't seem to have data on individual zones
+           so using an inner zone here to remove those rows that would have null activity_zone_ids */
+        inner join zones on zone_types.zone_type_id = zones.zone_type_id
+)
+
+select *
+from joined

--- a/transform/models/core/fct_activity_zones.sql
+++ b/transform/models/core/fct_activity_zones.sql
@@ -17,7 +17,8 @@ with zone_types as (
         , zones.min
         , zones.max
         , zones.zone_seconds
-        , zones.zone_index
+        /* _dlt_list_idx is 0 indexed, but zone_index should be 1 indexed */
+        , zones._dlt_list_idx + 1 as zone_index
         , 'Z' || zone_index as zone_name
         , zone_types.is_sensor_based
         , zone_types.has_custom_zone_set

--- a/transform/models/core/fct_activity_zones.yml
+++ b/transform/models/core/fct_activity_zones.yml
@@ -11,6 +11,19 @@ models:
         tests:
           - unique
           - not_null
+
+      - name: zone_index
+        description: >
+          Details the specific zone (e.g. 1, 2, 3, etc.)
+        tests:
+          - not_null
+          - dbt_utils.expression_is_true:
+              expression: "!= 0"
+          - dbt_expectations.expect_column_values_to_be_increasing:
+              sort_column: zone_index
+              strictly: true
+              group_by: [activity_zone_id]
+              step: 1
       
       - name: zone_name
         description: >

--- a/transform/models/core/fct_activity_zones.yml
+++ b/transform/models/core/fct_activity_zones.yml
@@ -1,0 +1,20 @@
+models:
+  - name: fct_activity_zones
+    description: >
+      One row per activity per zone.
+      For instance, if heart rate data is captured for an activity,
+      there will be 5 rows representing the 5 different heart rate zones
+      (and the time spent in them during the activity).
+      Same with respect to the other zone types of power and pace.
+    columns:
+      - name: activity_zone_id
+        tests:
+          - unique
+          - not_null
+      
+      - name: zone_name
+        description: >
+          "The name of the zone (e.g. 'Z2' for zone two)"
+        tests:
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: "^Z[0-9]{1,2}$"

--- a/transform/models/intermediate/int_activity_stream_points.yml
+++ b/transform/models/intermediate/int_activity_stream_points.yml
@@ -1,6 +1,6 @@
 models:
-  - name: fct_activity_stream_points
-    description: "One row per activity stream data point."
+  - name: int_activity_stream_points
+    description: "One row per activity stream data point (per type of stream)."
     columns:
       - name: activity_stream_point_id
         tests:

--- a/transform/models/intermediate/int_activity_streams.sql
+++ b/transform/models/intermediate/int_activity_streams.sql
@@ -1,0 +1,21 @@
+with activity_streams as (
+    select *
+    from {{ ref('stg_strava_activity_streams') }}
+)
+
+, dlt_loads as (
+    select *
+    from {{ ref('stg_strava_dlt_loads') }}
+)
+
+, joined as (
+    select
+        activity_streams.*
+        , dlt_loads.inserted_at
+    
+    from activity_streams
+        left join dlt_loads using (_dlt_load_id)
+)
+
+select *
+from joined

--- a/transform/models/intermediate/int_activity_streams.yml
+++ b/transform/models/intermediate/int_activity_streams.yml
@@ -1,0 +1,10 @@
+models:
+  - name: int_activity_streams
+    description: >
+      Strava activity streams data enchanced with dlt inserted_at info
+      to be leveraged in downstream incremental model.
+    columns:
+      - name: activity_stream_id
+        tests:
+          - unique
+          - not_null

--- a/transform/models/staging/strava/_source_strava.yml
+++ b/transform/models/staging/strava/_source_strava.yml
@@ -417,3 +417,15 @@ sources:
 
           - name: min__v_double
             data_type: double
+
+      # dlt metadata tables
+      - name: _dlt_loads
+        columns:
+          - name: load_id
+            tests:
+              - unique
+              - not_null
+
+          - name: inserted_at
+            tests:
+              - not_null

--- a/transform/models/staging/strava/stg_strava_activities.sql
+++ b/transform/models/staging/strava/stg_strava_activities.sql
@@ -22,6 +22,8 @@ with source as (
         /* Convert m/s to kph */
         , average_speed * (1/1000) * 3600 as speed_avg_metric
         , max_speed * (1/1000) * 3600 as speed_max_metric
+        , average_speed as speed_avg_raw
+        , max_speed as speed_max_raw
         , average_watts as power_avg
         , weighted_average_watts as power_weighted_avg
         , max_watts as power_max
@@ -33,6 +35,7 @@ with source as (
         , distance * (1/1609.344) as distance
         /* Convert m to km */
         , distance * (1/1000) as distance_metric
+        , distance as distance_raw
         , elapsed_time as elapsed_seconds
         , moving_time as moving_seconds
         /* Convert m to ft */
@@ -40,6 +43,7 @@ with source as (
         , elev_high * 3.280839895 as elevation_max
         /* Convert m to ft */
         , total_elevation_gain * 3.280839895 as elevation_gain
+        , total_elevation_gain as elevation_gain_metric
         , elev_low as elevation_min_metric
         , elev_high as elevation_max_metric
         , kilojoules

--- a/transform/models/staging/strava/stg_strava_activities.sql
+++ b/transform/models/staging/strava/stg_strava_activities.sql
@@ -6,7 +6,7 @@ with source as (
 , renamed as (
     select
         id as activity_id
-        , name
+        , name as activity_name
         , start_date as started_at
         , start_date_local as started_at_local
         , achievement_count
@@ -54,7 +54,7 @@ with source as (
         , photo_count as photo_count_at_upload
         , total_photo_count as photo_count
         , resource_state
-        , type
+        , type as activity_type
         , sport_type
         , suffer_score
         , timezone
@@ -83,7 +83,7 @@ with source as (
         , private as is_private
         , trainer as is_trainer
 
-        , athlete__id
+        , athlete__id as athlete_id
         , external_id
         , gear_id
         , map__id as map_id

--- a/transform/models/staging/strava/stg_strava_activities.sql
+++ b/transform/models/staging/strava/stg_strava_activities.sql
@@ -22,15 +22,15 @@ with source as (
         /* Convert m/s to kph */
         , average_speed * (1/1000) * 3600 as speed_avg_metric
         , max_speed * (1/1000) * 3600 as speed_max_metric
-        , average_watts as watts_avg
-        , weighted_average_watts as watts_weighted_avg
-        , max_watts as watts_max
+        , average_watts as power_avg
+        , weighted_average_watts as power_weighted_avg
+        , max_watts as power_max
         /* Conver C to F */
         , average_temp * (9/5) + 32 as temperature_avg
         , average_temp as temperature_avg_metric
         , comment_count
         /* Convert m to mi */
-        , distance * (1/1609.344) * 3600 as distance
+        , distance * (1/1609.344) as distance
         /* Convert m to km */
         , distance * (1/1000) as distance_metric
         , elapsed_time as elapsed_seconds

--- a/transform/models/staging/strava/stg_strava_activities.yml
+++ b/transform/models/staging/strava/stg_strava_activities.yml
@@ -41,6 +41,12 @@ models:
       - name: speed_max_metric
         description: "The maximum speed achieved during the activity, in kilometers per hour (kph)."
       
+      - name: speed_avg_raw
+        description: "The average speed during the activity, in meters per second (m/s)."
+      
+      - name: speed_max_raw
+        description: "The maximum speed achieved during the activity, in meters per second (m/s)."
+      
       - name: power_average
         description: "The average power output during the activity, in watts (W)."
       
@@ -62,6 +68,9 @@ models:
         description: "The total distance covered during the activity, in miles (mi)."
 
       - name: distance_metric
+        description: "The total distance covered during the activity, in kilometers (km)."
+
+      - name: distance_raw
         description: "The total distance covered during the activity, in meters (m)."
       
       - name: elapsed_seconds
@@ -71,7 +80,10 @@ models:
         description: "The total moving time of the activity, in seconds."
 
       - name: elevation_gain
-        description: "The total elevation gain during the activity, in feet."
+        description: "The total elevation gain during the activity, in feet (ft)."
+      
+      - name: elevation_gain_metric
+        description: "The total elevation gain during the activity, in meters (m)."
       
       - name: elevation_min
         description: "The lowest elevation reached during the activity, in feet (ft)."

--- a/transform/models/staging/strava/stg_strava_activities.yml
+++ b/transform/models/staging/strava/stg_strava_activities.yml
@@ -41,15 +41,15 @@ models:
       - name: speed_max_metric
         description: "The maximum speed achieved during the activity, in kilometers per hour (kph)."
       
-      - name: average_watts
+      - name: power_average
         description: "The average power output during the activity, in watts (W)."
       
-      - name: watts_weighted_avg
+      - name: power_weighted_avg
         description: >
           The weighted average power during the activity.
           This is Strava's version of "normalized power".
       
-      - name: watts_max
+      - name: power_max
         description: "The maximum power output during the activity, in watts (W)."
 
       - name: temperature_avg

--- a/transform/models/staging/strava/stg_strava_activities.yml
+++ b/transform/models/staging/strava/stg_strava_activities.yml
@@ -6,6 +6,9 @@ models:
         tests:
           - unique
           - not_null
+      
+      - name: activity_name
+        description: "The name of the activity."
 
       - name: started_at
         description: "The UTC start time of the activity."
@@ -104,6 +107,11 @@ models:
         description: >
           The total number of photos uploaded for the activity.
           Includes the photos that were added after the initial upload.
+      
+      - name: activity_type
+        description: >
+          The type of activity in PascalCase.
+          (e.g. Run, Ride, Walk, etc.)
       
       - name: utc_offset_seconds
         description: "The offset from UTC time, in seconds."

--- a/transform/models/staging/strava/stg_strava_activity_measurements.yml
+++ b/transform/models/staging/strava/stg_strava_activity_measurements.yml
@@ -1,8 +1,0 @@
-models:
-  - name: stg_strava_activity_measurements
-    description: "One row per activity per measurement type (heartrate, power, pace)."
-    columns:
-      - name: activity_measurement_id
-        tests:
-          - unique
-          - not_null

--- a/transform/models/staging/strava/stg_strava_activity_streams.sql
+++ b/transform/models/staging/strava/stg_strava_activity_streams.sql
@@ -7,7 +7,15 @@ with source as (
     select
         {{ dbt_utils.generate_surrogate_key(['_activities_id', 'type']) }} as activity_stream_id
         , _activities_id as activity_id
-        , type as stream_type
+        , case type
+            when 'temp' then 'temperature'
+            when 'grade_smooth' then 'grade'
+            when 'velocity_smooth' then 'velocity'
+            when 'moving' then 'is_moving'
+            when 'watts' then 'power'
+            else type
+        end as stream_type
+        , type as stream_type_raw
         , data as stream_json
         , from_json(data, '["int"]') as stream_list
         , series_type

--- a/transform/models/staging/strava/stg_strava_activity_streams.sql
+++ b/transform/models/staging/strava/stg_strava_activity_streams.sql
@@ -7,8 +7,9 @@ with source as (
     select
         {{ dbt_utils.generate_surrogate_key(['_activities_id', 'type']) }} as activity_stream_id
         , _activities_id as activity_id
-        , type
-        , data
+        , type as stream_type
+        , data as stream_json
+        , from_json(data, '["int"]') as stream_list
         , series_type
         , original_size
         , resolution

--- a/transform/models/staging/strava/stg_strava_activity_streams.sql
+++ b/transform/models/staging/strava/stg_strava_activity_streams.sql
@@ -10,7 +10,6 @@ with source as (
         , case type
             when 'temp' then 'temperature'
             when 'grade_smooth' then 'grade'
-            when 'velocity_smooth' then 'velocity'
             when 'moving' then 'is_moving'
             when 'watts' then 'power'
             else type

--- a/transform/models/staging/strava/stg_strava_activity_streams.yml
+++ b/transform/models/staging/strava/stg_strava_activity_streams.yml
@@ -15,3 +15,13 @@ models:
           - relationships:
               to: ref('stg_strava_activities')
               field: activity_id
+      
+      - name: stream_type
+        description: "Renamed identifier for the type of stream"
+        tests:
+          - not_null
+      
+      - name: stream_type_raw
+        description: >
+          Raw identifier for the type of stream
+          (i.e. as it's recorded in Strava).

--- a/transform/models/staging/strava/stg_strava_activity_zone_types.sql
+++ b/transform/models/staging/strava/stg_strava_activity_zone_types.sql
@@ -5,14 +5,13 @@ with source as (
 
 , renamed as (
     select
-        {{ dbt_utils.generate_surrogate_key(['_activities_id', 'type']) }} as activity_measurement_id
+        {{ dbt_utils.generate_surrogate_key(['_activities_id', 'type']) }} as activity_zone_type_id
         , _activities_id as activity_id
-        , _dlt_id as measurement_id
-        , type
+        , _dlt_id as zone_type_id
+        , type as zone_type
         , score
         , sensor_based as is_sensor_based
-        , custom_zones as has_custom_zone_set
-        
+        , coalesce(custom_zones, false) as has_custom_zone_set        
         , _dlt_id
         , _dlt_load_id
     

--- a/transform/models/staging/strava/stg_strava_activity_zone_types.yml
+++ b/transform/models/staging/strava/stg_strava_activity_zone_types.yml
@@ -1,0 +1,26 @@
+models:
+  - name: stg_strava_activity_zone_types
+    description: "One row per activity per zone type (heartrate, power, pace)."
+    columns:
+      - name: activity_zone_type_id
+        tests:
+          - unique
+          - not_null
+      
+      - name: is_sensor_based
+        description: >
+          Flag to denote whether the measurement comes from a physical device or is a Strava estimate.
+          For example, in a cycling activity, without a power meter, Strava will attempt to estimate power (this is wildly inaccurate).
+        tests:
+          - not_null
+          - accepted_values:
+              values: [true, false]
+      
+      - name: has_custom_zone_set
+        description: >
+          Flag to denote whether the user had their own custom zones setup when the activity was recorded
+          Custom zones are typically setup within the user's profile.
+        tests:
+          - not_null
+          - accepted_values:
+              values: [true, false]

--- a/transform/models/staging/strava/stg_strava_activity_zones.sql
+++ b/transform/models/staging/strava/stg_strava_activity_zones.sql
@@ -12,11 +12,10 @@ with source as (
         , min__v_double as pace_min
         , max__v_double as pace_max
         , time
-        , _dlt_parent_id as measurement_id
-
+        , _dlt_parent_id as zone_type_id
+        , _dlt_list_idx as zone_index
         , _dlt_root_id
         , _dlt_parent_id
-        , _dlt_list_idx
         , _dlt_id
     
     from source
@@ -27,11 +26,11 @@ with source as (
     select
         coalesce(min, pace_min) as min
         , coalesce(max, pace_max) as max
-        , time
-        , measurement_id
+        , time as zone_seconds
+        , zone_type_id
+        , zone_index
         , _dlt_root_id
         , _dlt_parent_id
-        , _dlt_list_idx
         , _dlt_id
     
     from renamed
@@ -39,7 +38,7 @@ with source as (
 
 , final as (
     select
-        {{ dbt_utils.generate_surrogate_key(['min', 'max', 'measurement_id']) }} as activity_measurement_zone_id
+        {{ dbt_utils.generate_surrogate_key(['min', 'max', 'zone_type_id']) }} as activity_zone_id
         , *
     
     from buckets_coalesced

--- a/transform/models/staging/strava/stg_strava_activity_zones.sql
+++ b/transform/models/staging/strava/stg_strava_activity_zones.sql
@@ -13,7 +13,7 @@ with source as (
         , max__v_double as pace_max
         , time
         , _dlt_parent_id as zone_type_id
-        , _dlt_list_idx as zone_index
+        , _dlt_list_idx
         , _dlt_root_id
         , _dlt_parent_id
         , _dlt_id
@@ -28,7 +28,7 @@ with source as (
         , coalesce(max, pace_max) as max
         , time as zone_seconds
         , zone_type_id
-        , zone_index
+        , _dlt_list_idx
         , _dlt_root_id
         , _dlt_parent_id
         , _dlt_id

--- a/transform/models/staging/strava/stg_strava_activity_zones.yml
+++ b/transform/models/staging/strava/stg_strava_activity_zones.yml
@@ -1,10 +1,10 @@
 models:
-  - name: stg_strava_activity_measurement_zones
+  - name: stg_strava_activity_zones
     description: >
-      One row per activity per measurement zone
+      One row per activity per unique zone.
       (e.g. heartrate Z1 thru Z5, power Z1 thru Z5, pace Z1 thru Z5).
     columns:
-      - name: activity_measurement_zone_id
+      - name: activity_zone_id
         tests:
           - unique
           - not_null
@@ -25,11 +25,11 @@ models:
         tests:
           - not_null
       
-      - name: time
+      - name: zone_seconds
         description: "Time in zone in seconds."
         tests:
           - not_null
       
-      - name: measurement_id
+      - name: zone_type_id
         tests:
           - not_null

--- a/transform/models/staging/strava/stg_strava_dlt_loads.sql
+++ b/transform/models/staging/strava/stg_strava_dlt_loads.sql
@@ -1,0 +1,18 @@
+with source as (
+    select *
+    from {{ source('strava', '_dlt_loads') }}
+)
+
+, renamed as (
+    select
+        load_id as _dlt_load_id
+        , schema_name
+        , status
+        , inserted_at
+        , schema_version_hash
+    
+    from source
+)
+
+select *
+from renamed

--- a/transform/models/staging/strava/stg_strava_dlt_loads.yml
+++ b/transform/models/staging/strava/stg_strava_dlt_loads.yml
@@ -1,0 +1,10 @@
+models:
+  - name: stg_strava_dlt_loads
+    description: >
+      Load info for the strava.py dlt pipeline.
+      One row per dlt load job.
+    columns:
+      - name: _dlt_load_id
+        tests:
+          - unique
+          - not_null

--- a/transform/package-lock.yml
+++ b/transform/package-lock.yml
@@ -3,4 +3,8 @@ packages:
     version: 1.3.0
   - package: dbt-labs/codegen
     version: 0.13.1
-sha1_hash: 141ef14b71cb0677586b350fda3a0c419161611e
+  - package: calogica/dbt_expectations
+    version: 0.10.4
+  - package: calogica/dbt_date
+    version: 0.10.1
+sha1_hash: bae2ff2580b6d9af8dce0cf1de0dedc52aa52c28

--- a/transform/packages.yml
+++ b/transform/packages.yml
@@ -4,3 +4,6 @@ packages:
   
   - package: dbt-labs/codegen
     version: [">=0.13.1", "<0.14.0"]
+  
+  - package: calogica/dbt_expectations
+    version: [">=0.10.4", "<0.11.0"]


### PR DESCRIPTION
## Overview
Adds core fact models to analyze Strava activity data

<img width="2428" alt="image" src="https://github.com/user-attachments/assets/68cdf625-5f07-45c3-82af-76853387f80e" /><br>

| model_name | description |
| --- | --- |
| `fct_activities` | one row per Strava activity; contains the high level details of the activity |
| `fct_activity_data_points`&nbsp;&nbsp;&nbsp; | the individual data points (heart rate, power, velocity, altitude, etc.) recorded throughout an activity as a function of time (many rows) |
| `fct_activity_zones` | the time an athlete spent in a given zone during an activity (e.g. heart rate Z2), and what the range that defined that zone was |

## Other Notes
- `int_activity_stream_points` is an incremental model that processes newly ingested streams based off dlt's [inserted_at](https://github.com/datadisciple/strava-datastack/blob/e2935a6bde74690496a4c77bc75d83014516f1c6/transform/models/intermediate/int_activity_stream_points.sql#L15) timestamp
  - this model expands ~12,000 `int_activity_streams` rows -> 50 M rows
  - duckDB 🦆 currently handles the `--full-refresh` in ~30s 🐇
  <img width="755" alt="image" src="https://github.com/user-attachments/assets/635a9242-8a73-4588-a57e-1ee37534619b" />
  
  <img width="293" alt="image" src="https://github.com/user-attachments/assets/592b3039-601a-4b5a-aae8-3be96f881a82" /> → <img width="336" alt="image" src="https://github.com/user-attachments/assets/cf3fd443-86f0-446f-ac7b-1ef04800e193" />


## Future Enhancements
- Add lat/long data for start/stop locations into `fct_activities`
- Look into the useless Z1 power in running activities (consider merging Z1 and Z2 together in these instances)
  <img width="1152" alt="image" src="https://github.com/user-attachments/assets/9be4c93a-8c73-470d-bd8b-44dd554dce00" />
